### PR TITLE
Fix the issue where permission request is prompted for saving files when it's not needed on Android Q and above

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 ReactNativeWebView_kotlinVersion=1.3.50
-ReactNativeWebView_compileSdkVersion=28
-ReactNativeWebView_buildToolsVersion=28.0.3
+ReactNativeWebView_compileSdkVersion=29
+ReactNativeWebView_buildToolsVersion=29.0.3
 ReactNativeWebView_targetSdkVersion=28

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -219,16 +219,13 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
   }
 
   public boolean grantFileDownloaderPermissions() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+    // Permission not required for Android Q and above
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       return true;
     }
 
-    boolean result = true;
-    if (ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-      result = false;
-    }
-
-    if (!result) {
+    boolean result = ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+    if (!result && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       PermissionAwareActivity activity = getPermissionAwareActivity();
       activity.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, FILE_DOWNLOAD_PERMISSION_REQUEST, webviewFileDownloaderPermissionListener);
     }

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -252,13 +252,13 @@ To be able to save images to the gallery you need to specify this permission in 
 ##### Android
 
 On Android, integration with the DownloadManager is built-in.
-All you have to do to support downloads is add these permissions in AndroidManifest.xml:
+Add this permisison in AndroidManifest.xml (only required if your app supports Android versions lower than 10):
 
 ```xml
 <manifest ...>
   ......
 
-  <!-- this is required to save files on Android  -->
+  <!-- this is required to save files on Android versions lower than 10 -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   ......

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "29.0.3"
         minSdkVersion = 16
-        compileSdkVersion = 28
+        compileSdkVersion = 29
         targetSdkVersion = 28
     }
     repositories {


### PR DESCRIPTION
Fix the issue where permission request is prompted for saving files when it's not needed on Android Q and above. Also fixes an issue with not checking WRITE_EXTERNAL_STORAGE manifest permission for Android versions below M.

See: https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE

Expected/new behavior for grantFileDownloaderPermissions():
1. Android version below M, if permission not included in the manifest: return false
2. Android version below M, if permission included in the manifest: return true
3. Android version M-Q, if permission already granted for app: return true
4. Android version M-Q, if permission not granted for app: request runtime permission and return false
5. Android version Q and above: permission not required; return true
